### PR TITLE
Initial alpha release of Confluent Cloud Claude Code plugin

### DIFF
--- a/.claude/commands/api-keys-create.md
+++ b/.claude/commands/api-keys-create.md
@@ -1,0 +1,31 @@
+---
+description: Create a cluster-scoped API key
+allowed-tools: mcp__confluent-infra__list_environments, mcp__confluent-infra__list_clusters, mcp__confluent-infra__create_api_key
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+Help me create a cluster-scoped API key for a Kafka cluster.
+
+Follow these steps:
+
+1. **Resolve environment** — First, read the file `.confluent-context.json` in the project root. If it exists and contains an `environment_id`, use that environment automatically and tell me: "Using active environment **{name}** (`{id}`). Run `/project:environments-use` to change."
+   If the file doesn't exist or has no environment set, call `list_environments` and ask me to pick one.
+
+2. **Pick cluster** — Call `list_clusters` for the chosen environment. Ask me to pick a cluster.
+
+3. **Name the key** — Ask for a display name. Suggest a default like "my-app-key" or something contextual.
+
+4. **Create the key** — Call `create_api_key` with the environment ID, cluster ID, and display name.
+
+5. **Display the result** — Show:
+   - API Key ID
+   - API Secret
+   - Note that credentials have been automatically saved to `.confluent-context.json` for use by topic commands.
+
+6. **IMPORTANT:** Strongly remind me to save the API secret — it is only shown once and cannot be retrieved later! (The secret is stored in the local context file, but you should still save it separately for use outside Claude Code.)
+
+7. Suggest next steps:
+   - "Use this key to create topics with `/project:topics-create`"
+   - "List your API keys with `/project:api-keys-list`"

--- a/.claude/commands/api-keys-delete.md
+++ b/.claude/commands/api-keys-delete.md
@@ -1,0 +1,23 @@
+---
+description: Delete an API key
+allowed-tools: mcp__confluent-infra__list_api_keys, mcp__confluent-infra__delete_api_key
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+Help me delete an API key.
+
+Follow these steps:
+
+1. Call `list_api_keys` to show existing keys as a numbered list with Key ID, display name, and resource.
+
+2. Ask me to pick the key to delete.
+
+3. **WARNING:** Warn that deleting an API key is irreversible — any applications using this key will lose access immediately.
+
+4. Ask for explicit confirmation: "Are you sure you want to delete API key **{key_id}**? This cannot be undone."
+
+5. Once confirmed, call `delete_api_key` with the key ID. The key is automatically removed from `.confluent-context.json` as well.
+
+6. Confirm deletion was successful.

--- a/.claude/commands/api-keys-list.md
+++ b/.claude/commands/api-keys-list.md
@@ -1,0 +1,19 @@
+---
+description: List API keys in the organization
+allowed-tools: mcp__confluent-infra__list_api_keys
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+List API keys in the Confluent Cloud organization.
+
+1. Ask me if I want to filter by a specific cluster resource ID, or list all keys.
+
+2. Call `list_api_keys` with the optional `resource_id` filter.
+
+3. Present the results as a table:
+   | Key ID | Display Name | Owner | Resource | Created |
+   |--------|-------------|-------|----------|---------|
+
+4. If no keys exist, suggest creating one with `/project:api-keys-create`.

--- a/.claude/commands/clusters-create.md
+++ b/.claude/commands/clusters-create.md
@@ -1,0 +1,113 @@
+---
+description: Create a new Kafka cluster in Confluent Cloud
+allowed-tools: mcp__confluent-infra__list_environments, mcp__confluent-infra__create_cluster, mcp__confluent-infra__get_cluster, mcp__confluent-infra__create_api_key
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+Help me create a new Kafka cluster in Confluent Cloud.
+
+## Step 1: Resolve environment
+
+Read the file `.confluent-context.json` in the project root. If it exists and contains an `environment_id`, use that environment automatically and tell me: "Using active environment **{name}** (`{id}`). Run `/project:environments-use` to change."
+If the file doesn't exist or has no environment set, call `list_environments` to show available environments. Present as a numbered list with ID and name. Ask me to pick one (or offer to create a new one with `/project:environments-create`).
+
+## Step 2: Gather cluster configuration (part 1 — name, type, cloud)
+
+Use the `AskUserQuestion` tool to collect name, type, and cloud provider in a **single call** with 3 questions:
+
+**Question 1 — Cluster name** (header: "Name")
+- Options: "my-kafka-cluster" (description: "Default cluster name"), "dev-cluster" (description: "Development cluster"), "prod-cluster" (description: "Production cluster")
+- The user can also type a custom name
+
+**Question 2 — Cluster type** (header: "Type")
+- Option 1: "Basic" (description: "First eCKU free, then $0.14/eCKU-hr. 99.5% SLA. Great for dev/test.")
+- Option 2: "Standard" (description: "$0.75/eCKU-hr. 99.9-99.99% SLA. For production workloads.")
+- Option 3: "Enterprise (Coming Soon)" (description: "$1.75/eCKU-hr. Private networking, self-managed encryption.")
+- Option 4: "Dedicated (Coming Soon)" (description: "$2.66/CKU-hr. Fully customizable networking and throughput.")
+
+**Question 3 — Cloud provider** (header: "Cloud")
+- Option 1: "AWS" (description: "Amazon Web Services")
+- Option 2: "GCP" (description: "Google Cloud Platform")
+- Option 3: "Azure" (description: "Microsoft Azure")
+
+## Step 2b: Gather cluster configuration (part 2 — region)
+
+After receiving the cloud provider selection, use `AskUserQuestion` with a **single question** showing regions specific to the chosen provider. The user can always type a custom region.
+
+**If AWS selected** (header: "Region"):
+- Option 1: "us-east-1" (description: "N. Virginia (default)")
+- Option 2: "us-west-2" (description: "Oregon")
+- Option 3: "eu-west-1" (description: "Ireland")
+- Option 4: "eu-central-1" (description: "Frankfurt")
+
+**If GCP selected** (header: "Region"):
+- Option 1: "us-east1" (description: "South Carolina (default)")
+- Option 2: "us-west1" (description: "Oregon")
+- Option 3: "europe-west1" (description: "Belgium")
+- Option 4: "europe-west2" (description: "London")
+
+**If Azure selected** (header: "Region"):
+- Option 1: "eastus" (description: "East US (default)")
+- Option 2: "westus2" (description: "West US 2")
+- Option 3: "westeurope" (description: "Netherlands")
+- Option 4: "southeastasia" (description: "Singapore")
+
+## Step 3: Handle special selections
+
+**If Enterprise or Dedicated selected:** Tell the user: "Enterprise and Dedicated cluster types are **coming soon** to the Claude Code plugin. For now, you can create these through the [Confluent Cloud Console](https://confluent.cloud)." Then re-ask with only Basic and Standard as options.
+
+**If Standard selected:** Use `AskUserQuestion` for one more question:
+
+**Uptime SLA** (header: "SLA")
+- Option 1: "99.9% (Recommended)" (description: "Single zone. Good for development or staging.")
+- Option 2: "99.99%" (description: "Multi zone. Recommended for production. Minimum 2 eCKUs.")
+
+## Step 4: Confirm and create
+
+Show a summary in the Confluent Cloud console style:
+
+```
+Summary
+─────────────────────────────
+Cluster type:   Basic
+Provider:       Amazon Web Services
+Region:         N. Virginia (us-east-1)
+Uptime SLA:     99.5%, Single zone
+Networking:     Internet
+Minimum eCKUs:  1
+```
+
+Ask for confirmation, then call `create_cluster` with:
+- The chosen display_name
+- The chosen environment_id
+- The chosen cloud provider
+- The chosen region
+- cluster_type: "BASIC" or "STANDARD"
+- availability: "SINGLE_ZONE" (or "MULTI_ZONE" if Standard with 99.99% SLA)
+
+## Step 5: Wait for provisioning
+
+The cluster will start in PROVISIONING status. Poll using `get_cluster` every 30 seconds until `status.phase` is `PROVISIONED`. Show progress updates. Timeout after 15 minutes.
+
+## Step 6: Create API key
+
+Once provisioned, automatically call `create_api_key`. The credentials are automatically saved to `.confluent-context.json` for use by topic commands. Display:
+- API Key ID
+- API Secret (**remind me to save this — it's only shown once!**)
+
+## Step 7: Final summary
+
+Show:
+- Environment: name (ID)
+- Cluster: name (ID)
+- Cluster type & SLA
+- Cloud/Region
+- Bootstrap endpoint
+- REST endpoint
+- API Key ID (remind to save the secret)
+
+Suggest next steps:
+- "Create a topic with `/project:topics-create`"
+- "Or set up a full streaming app with `/project:setup-streaming-app`"

--- a/.claude/commands/clusters-delete.md
+++ b/.claude/commands/clusters-delete.md
@@ -1,0 +1,26 @@
+---
+description: Delete a Kafka cluster from Confluent Cloud
+allowed-tools: mcp__confluent-infra__list_environments, mcp__confluent-infra__list_clusters, mcp__confluent-infra__delete_cluster
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+Help me delete a Kafka cluster from Confluent Cloud.
+
+Follow these steps:
+
+1. **Resolve environment** — First, read the file `.confluent-context.json` in the project root. If it exists and contains an `environment_id`, use that environment automatically and tell me: "Using active environment **{name}** (`{id}`). Run `/project:environments-use` to change."
+   If the file doesn't exist or has no environment set, call `list_environments` and ask me to pick one.
+
+2. Call `list_clusters` for the chosen environment. Show clusters as a numbered list with ID, name, and status.
+
+3. Ask me to pick the cluster to delete.
+
+4. **WARNING:** Warn that deleting a cluster is irreversible — all topics and data will be lost.
+
+5. Ask for explicit confirmation: "Are you sure you want to delete cluster **{name}** (`{id}`)? This cannot be undone."
+
+6. Once confirmed, call `delete_cluster` with the cluster ID and environment ID.
+
+7. Confirm deletion was successful.

--- a/.claude/commands/clusters-list.md
+++ b/.claude/commands/clusters-list.md
@@ -1,0 +1,20 @@
+---
+description: List all Kafka clusters in a Confluent Cloud environment
+allowed-tools: mcp__confluent-infra__list_environments, mcp__confluent-infra__list_clusters
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+List all Kafka clusters in a Confluent Cloud environment.
+
+1. **Resolve environment** — First, read the file `.confluent-context.json` in the project root. If it exists and contains an `environment_id`, use that environment automatically and tell me: "Using active environment **{name}** (`{id}`). Run `/project:environments-use` to change."
+   If the file doesn't exist or has no environment set, call `list_environments` and ask me to pick one.
+
+2. Call `list_clusters` for the chosen environment.
+
+3. Present the results as a table:
+   | ID | Name | Cloud | Region | Type | Status |
+   |----|------|-------|--------|------|--------|
+
+4. If no clusters exist, suggest creating one with `/project:clusters-create`.

--- a/.claude/commands/environments-create.md
+++ b/.claude/commands/environments-create.md
@@ -1,0 +1,38 @@
+---
+description: Create a new Confluent Cloud environment
+allowed-tools: mcp__confluent-infra__create_environment, mcp__confluent-infra__list_environments
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+Help me create a new Confluent Cloud environment.
+
+## Step 1: Gather configuration
+
+Use the `AskUserQuestion` tool to present an interactive form with these questions in a **single call**:
+
+**Question 1 — Environment name** (header: "Name")
+- Options: "development" (description: "Good for testing and experimentation"), "staging" (description: "Pre-production environment"), "production" (description: "Production workloads")
+- The user can also type a custom name
+
+**Question 2 — Stream Governance package** (header: "Governance")
+- Option 1: "Essentials (Default)" (description: "Free to start, $0.002/schema/hr after 100 free schemas. Includes Schema Registry.")
+- Option 2: "Advanced (Recommended)" (description: "$1/hr, $0/schema/hr with up to 20k schemas. Enterprise-ready governance.")
+
+## Step 2: Create the environment
+
+Once the user submits the form, call `create_environment` with:
+- `display_name`: the chosen name
+- `stream_governance_package`: "ESSENTIALS" if Essentials selected, "ADVANCED" if Advanced selected
+
+## Step 3: Show result
+
+Display:
+- Environment ID (e.g., `env-abc123`)
+- Display name
+- Stream governance package
+
+Suggest next steps:
+- "You can now create a Kafka cluster in this environment using `/project:clusters-create`"
+- "Set this as your active environment with `/project:environments-use`"

--- a/.claude/commands/environments-delete.md
+++ b/.claude/commands/environments-delete.md
@@ -1,0 +1,25 @@
+---
+description: Delete a Confluent Cloud environment
+allowed-tools: mcp__confluent-infra__list_environments, mcp__confluent-infra__delete_environment, mcp__confluent-infra__list_clusters
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+Help me delete a Confluent Cloud environment.
+
+Follow these steps:
+
+1. **Resolve environment** — First, read the file `.confluent-context.json` in the project root. If it exists and contains an `environment_id`, offer that as the default but still call `list_environments` to show all options (since deletion is destructive, always confirm which one).
+
+2. Ask me to pick the environment to delete.
+
+3. **WARNING:** Before deleting, warn me that all clusters and resources in the environment must be deleted first. Call `list_clusters` for the selected environment to check for existing clusters.
+   - If clusters exist, list them and tell me to delete them first using `/project:clusters-delete`.
+   - If no clusters exist, proceed.
+
+4. Ask for explicit confirmation: "Are you sure you want to delete environment **{name}** (`{id}`)? This cannot be undone."
+
+5. Once confirmed, call `delete_environment` with the environment ID.
+
+6. Confirm deletion was successful.

--- a/.claude/commands/environments-list.md
+++ b/.claude/commands/environments-list.md
@@ -1,0 +1,17 @@
+---
+description: List all Confluent Cloud environments
+allowed-tools: mcp__confluent-infra__list_environments
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+List all Confluent Cloud environments in the organization.
+
+1. Call `list_environments` to retrieve all environments.
+
+2. Present the results as a table:
+   | ID | Name | Stream Governance |
+   |----|------|-------------------|
+
+3. If no environments exist, suggest creating one with `/project:environments-create`.

--- a/.claude/commands/environments-update.md
+++ b/.claude/commands/environments-update.md
@@ -1,0 +1,40 @@
+---
+description: Update an existing Confluent Cloud environment
+allowed-tools: mcp__confluent-infra__list_environments, mcp__confluent-infra__update_environment
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+Help me update an existing Confluent Cloud environment.
+
+## Step 1: Resolve environment
+
+Read the file `.confluent-context.json` in the project root. If it exists and has an `environment_id`, offer to update that environment by default. Otherwise, call `list_environments` and ask me to pick one.
+
+## Step 2: Gather changes
+
+Use the `AskUserQuestion` tool to present an interactive form:
+
+**Question 1 — What to update** (header: "Update", multiSelect: true)
+- Option 1: "Rename" (description: "Change the environment display name")
+- Option 2: "Stream Governance" (description: "Change governance package. Note: downgrading from Advanced to Essentials is not allowed once Schema Registry is provisioned.")
+
+Then, based on selections, ask follow-up questions using `AskUserQuestion`:
+
+**If Rename selected** — ask for the new name (free text via "Other")
+
+**If Stream Governance selected:**
+- Option 1: "Essentials" (description: "Free to start, $0.002/schema/hr after 100 free schemas")
+- Option 2: "Advanced" (description: "$1/hr, $0/schema/hr with up to 20k schemas. Enterprise-ready governance.")
+
+## Step 3: Confirm and update
+
+Summarize the changes and call `update_environment` with the environment ID and updated fields.
+
+## Step 4: Show result
+
+Display:
+- Environment ID
+- Updated display name
+- Stream governance package

--- a/.claude/commands/environments-use.md
+++ b/.claude/commands/environments-use.md
@@ -1,0 +1,28 @@
+---
+description: Set the active Confluent Cloud environment for subsequent commands
+allowed-tools: mcp__confluent-infra__list_environments
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+Help me set the active Confluent Cloud environment so I don't have to pick it every time.
+
+Follow these steps:
+
+1. Call `list_environments` to show available environments as a numbered list with ID and name.
+
+2. Ask me to pick the environment I want to use as my default.
+
+3. Read the existing `.confluent-context.json` file first (if it exists) to preserve any existing fields like `api_keys`. Then update only the `environment_id` and `environment_name` fields and write it back. If the file doesn't exist, create it with this format:
+   ```json
+   {
+     "environment_id": "env-xxx",
+     "environment_name": "my-environment"
+   }
+   ```
+
+4. Confirm the active environment has been set:
+   - "Active environment set to **{name}** (`{id}`)"
+   - "All subsequent commands (`/project:clusters-create`, `/project:topics-create`, etc.) will use this environment automatically."
+   - "To switch environments, run `/project:environments-use` again."

--- a/.claude/commands/setup-streaming-app.md
+++ b/.claude/commands/setup-streaming-app.md
@@ -1,0 +1,116 @@
+---
+description: Set up a complete Confluent Cloud streaming application from scratch
+allowed-tools: mcp__confluent-infra__create_environment, mcp__confluent-infra__list_environments, mcp__confluent-infra__create_cluster, mcp__confluent-infra__get_cluster, mcp__confluent-infra__create_api_key, mcp__confluent-infra__create_topic
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+Help me set up a complete Confluent Cloud streaming application from scratch.
+
+This is an end-to-end workflow. Use `AskUserQuestion` interactive forms throughout to collect configuration. Walk me through each step, confirming before proceeding to the next.
+
+## Step 1: Resolve or Create Environment
+
+Read `.confluent-context.json` in the project root. If it has an `environment_id`, use `AskUserQuestion` to ask:
+
+**Use existing environment?** (header: "Environment")
+- Option 1: "Use {name} ({id})" (description: "Continue with the active environment")
+- Option 2: "Create new" (description: "Set up a fresh environment")
+
+If creating new, use `AskUserQuestion`:
+
+**Question 1 — Environment name** (header: "Name")
+- Options: "development" (description: "Good for testing"), "staging" (description: "Pre-production"), "production" (description: "Production workloads")
+
+**Question 2 — Stream Governance** (header: "Governance")
+- Option 1: "Essentials" (description: "Free to start, $0.002/schema/hr after 100 free schemas")
+- Option 2: "Advanced (Recommended)" (description: "$1/hr. Enterprise-ready governance with up to 20k schemas")
+
+Call `create_environment` and save to `.confluent-context.json`.
+
+## Step 2: Create Kafka Cluster
+
+Use `AskUserQuestion` to collect all cluster options in a **single call**:
+
+**Question 1 — Cluster name** (header: "Name")
+- Options: "my-kafka-cluster" (description: "Default name"), "dev-cluster" (description: "Development"), "prod-cluster" (description: "Production")
+
+**Question 2 — Cloud provider** (header: "Cloud")
+- Option 1: "AWS" (description: "Amazon Web Services")
+- Option 2: "GCP" (description: "Google Cloud Platform")
+- Option 3: "Azure" (description: "Microsoft Azure")
+
+**Question 3 — Region** (header: "Region")
+- Option 1: "us-east-1" (description: "N. Virginia (AWS default)")
+- Option 2: "us-west-2" (description: "Oregon")
+- Option 3: "eu-west-1" (description: "Ireland")
+
+Adapt region options based on cloud provider selection. Call `create_cluster` with type BASIC, SINGLE_ZONE.
+
+Poll `get_cluster` every 30 seconds until PROVISIONED (timeout 15 minutes). Show progress.
+
+## Step 3: Create API Key
+
+Once cluster is provisioned, call `create_api_key` automatically. Credentials are automatically saved to `.confluent-context.json` for use by topic commands.
+- Display API Key and Secret
+- **Strongly remind to save the secret — it's only shown once!** (The secret is stored in the local context file, but save it separately for use outside Claude Code.)
+
+## Step 4: Create Topics
+
+Use `AskUserQuestion`:
+
+**Question 1 — Topics** (header: "Topics", multiSelect: true)
+- Option 1: "events" (description: "General event stream")
+- Option 2: "commands" (description: "Command/request stream")
+- Option 3: "notifications" (description: "Notification stream")
+- The user can also type custom topic names
+
+For each topic, call `create_topic` with 6 partitions and 7-day retention by default. Cluster API credentials are auto-resolved from context — no need to pass them explicitly.
+
+## Step 5: Scaffold Application (Optional)
+
+Use `AskUserQuestion`:
+
+**Scaffold a starter app?** (header: "Scaffold")
+- Option 1: "Node.js / TypeScript" (description: "Producer + consumer using kafkajs")
+- Option 2: "Python" (description: "Producer + consumer using confluent-kafka")
+- Option 3: "Java" (description: "Producer + consumer using Kafka client")
+- Option 4: "Skip" (description: "No application scaffolding needed")
+
+If not skipped, create producer + consumer files with:
+- Connection config pointing to the new cluster
+- Placeholder for API key/secret (reference environment variables)
+- Basic error handling and comments
+
+## Step 6: Summary
+
+Show a final summary:
+
+```
+Confluent Cloud Streaming App — Setup Complete
+
+Environment:  <name> (<env-id>)
+Cluster:      <name> (<cluster-id>)
+Cloud/Region: <cloud> / <region>
+Type:         Basic (Single Zone)
+
+Endpoints:
+  Bootstrap:  <bootstrap-url>
+  REST:       <rest-endpoint>
+
+API Key:      <key-id> (secret was shown above — make sure you saved it!)
+
+Topics:
+  - <topic-1> (6 partitions)
+  - <topic-2> (6 partitions)
+
+Application files: (if scaffolded)
+  - producer.<ext>
+  - consumer.<ext>
+```
+
+Suggest what to do next:
+- "Run the producer to send test messages"
+- "Open the Confluent Cloud console to monitor your cluster"
+- "Create additional topics with `/project:topics-create`"

--- a/.claude/commands/topics-create.md
+++ b/.claude/commands/topics-create.md
@@ -1,0 +1,65 @@
+---
+description: Create a Kafka topic in a Confluent Cloud cluster
+allowed-tools: mcp__confluent-infra__list_environments, mcp__confluent-infra__list_clusters, mcp__confluent-infra__list_api_keys, mcp__confluent-infra__create_api_key, mcp__confluent-infra__create_topic
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+Help me create a Kafka topic in Confluent Cloud.
+
+## Step 1: Resolve environment
+
+Read the file `.confluent-context.json` in the project root. If it exists and contains an `environment_id`, use that environment automatically and tell me: "Using active environment **{name}** (`{id}`). Run `/project:environments-use` to change."
+If the file doesn't exist or has no environment set, call `list_environments` and ask me to pick one.
+
+## Step 2: Pick cluster
+
+Call `list_clusters` for the chosen environment. If only one cluster exists, use it automatically. If multiple, present them and ask me to pick one. If none exist, suggest `/project:clusters-create`.
+
+## Step 3: Resolve cluster API key
+
+First, check `.confluent-context.json` for a stored API key for this cluster (under `api_keys[cluster_id]`). If found, use it automatically and tell me: "Using stored API key **{api_key}** for cluster `{cluster_id}`."
+
+If no stored key is found, call `list_api_keys` with the cluster's `resource_id` to check for existing cluster-scoped API keys.
+- If keys exist, offer to create a new one with `create_api_key` (credentials are saved automatically).
+- If no keys exist, offer to create one with `create_api_key`. Credentials are saved automatically to context.
+
+## Step 4: Gather topic configuration
+
+Use the `AskUserQuestion` tool to present an interactive form in a **single call**:
+
+**Question 1 — Topic name** (header: "Topic")
+- Options: "events" (description: "General event stream"), "commands" (description: "Command/request stream"), "notifications" (description: "Notification stream")
+- The user can also type a custom name (e.g., `orders.created`, `user.events`)
+
+**Question 2 — Partitions** (header: "Partitions")
+- Option 1: "6 (Recommended)" (description: "Good default for most development and production use cases")
+- Option 2: "1" (description: "Single partition, useful for strict ordering")
+- Option 3: "12" (description: "Higher parallelism for high-throughput topics")
+
+**Question 3 — Retention** (header: "Retention")
+- Option 1: "7 days (Recommended)" (description: "Default retention, good for most use cases")
+- Option 2: "1 day" (description: "Short retention for transient data")
+- Option 3: "30 days" (description: "Longer retention for replay/audit")
+- Option 4: "Infinite" (description: "Never delete messages. Set retention to -1.")
+
+## Step 5: Create the topic
+
+Call `create_topic` with the cluster ID, environment ID, cluster API key, cluster API secret, topic name, partitions count, and retention_ms:
+- 7 days = 604800000
+- 1 day = 86400000
+- 30 days = 2592000000
+- Infinite = -1
+
+## Step 6: Confirm creation
+
+Show the result:
+- Topic name
+- Partition count
+- Retention policy
+- Cluster it was created on
+
+Suggest next steps:
+- "You can produce messages to this topic or create more topics"
+- "List existing topics with `/project:topics-list`"

--- a/.claude/commands/topics-delete.md
+++ b/.claude/commands/topics-delete.md
@@ -1,0 +1,33 @@
+---
+description: Delete a Kafka topic from a cluster
+allowed-tools: mcp__confluent-infra__list_environments, mcp__confluent-infra__list_clusters, mcp__confluent-infra__list_api_keys, mcp__confluent-infra__create_api_key, mcp__confluent-infra__list_topics, mcp__confluent-infra__delete_topic
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+Help me delete a Kafka topic from a cluster.
+
+Follow these steps:
+
+1. **Resolve environment** — First, read the file `.confluent-context.json` in the project root. If it exists and contains an `environment_id`, use that environment automatically and tell me: "Using active environment **{name}** (`{id}`). Run `/project:environments-use` to change."
+   If the file doesn't exist or has no environment set, call `list_environments` and ask me to pick one.
+
+2. **Pick cluster** — Call `list_clusters` for the chosen environment. Ask me to pick a cluster.
+
+3. **Get cluster API key** — First, check `.confluent-context.json` for a stored API key for this cluster (under `api_keys[cluster_id]`). If found, use it automatically and tell me: "Using stored API key **{api_key}** for cluster `{cluster_id}`."
+   If no stored key is found, call `list_api_keys` with the cluster's `resource_id` to check for existing keys.
+   - If keys exist, offer to create a new one with `create_api_key` (credentials are saved automatically).
+   - If no keys exist, offer to create one with `create_api_key`. Credentials are saved automatically to context.
+
+4. **List topics** — Call `list_topics` to show existing topics. Present as a numbered list.
+
+5. Ask me to pick the topic to delete.
+
+6. **WARNING:** Warn that deleting a topic is irreversible — all messages will be lost.
+
+7. Ask for explicit confirmation: "Are you sure you want to delete topic **{name}**? This cannot be undone."
+
+8. Once confirmed, call `delete_topic` with the cluster ID, environment ID, cluster API credentials, and topic name.
+
+9. Confirm deletion was successful.

--- a/.claude/commands/topics-list.md
+++ b/.claude/commands/topics-list.md
@@ -1,0 +1,27 @@
+---
+description: List all topics in a Kafka cluster
+allowed-tools: mcp__confluent-infra__list_environments, mcp__confluent-infra__list_clusters, mcp__confluent-infra__list_api_keys, mcp__confluent-infra__create_api_key, mcp__confluent-infra__list_topics
+---
+
+**Before starting:** If any tool call fails with "Missing required environment variables", tell the user:
+"Set your Confluent Cloud API credentials — generate at https://confluent.cloud/settings/api-keys, then `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code."
+
+List all topics in a Kafka cluster.
+
+1. **Resolve environment** — First, read the file `.confluent-context.json` in the project root. If it exists and contains an `environment_id`, use that environment automatically and tell me: "Using active environment **{name}** (`{id}`). Run `/project:environments-use` to change."
+   If the file doesn't exist or has no environment set, call `list_environments` and ask me to pick one.
+
+2. **Pick cluster** — Call `list_clusters` for the chosen environment. Ask me to pick a cluster.
+
+3. **Get cluster API key** — First, check `.confluent-context.json` for a stored API key for this cluster (under `api_keys[cluster_id]`). If found, use it automatically and tell me: "Using stored API key **{api_key}** for cluster `{cluster_id}`."
+   If no stored key is found, call `list_api_keys` with the cluster's `resource_id` to check for existing keys.
+   - If keys exist, offer to create a new one with `create_api_key` (credentials are saved automatically).
+   - If no keys exist, offer to create one with `create_api_key`. Credentials are saved automatically to context.
+
+4. **List topics** — Call `list_topics` with the cluster ID, environment ID, and cluster API credentials.
+
+5. **Present results** — Show topics as a table:
+   | Topic Name | Partitions |
+   |------------|------------|
+
+6. If no topics exist, suggest creating one with `/project:topics-create`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+.env
+.env.*
+.idea/
+*.tsbuildinfo
+.confluent-context.json
+.DS_Store
+.claude/settings.local.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "confluent-infra": {
+      "command": "node",
+      "args": ["dist/index.js"],
+      "env": {
+        "CONFLUENT_CLOUD_API_KEY": "${CONFLUENT_CLOUD_API_KEY}",
+        "CONFLUENT_CLOUD_API_SECRET": "${CONFLUENT_CLOUD_API_SECRET}"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,117 @@
+# Confluent Cloud Claude Code Plugin
+
+Claude-first interface for provisioning and managing Confluent Cloud infrastructure via MCP.
+
+## Auth Model
+
+Two credential layers:
+
+| Layer | Credentials | Source | Used For |
+|-------|------------|--------|----------|
+| **Management plane** | Cloud API key/secret | `CONFLUENT_CLOUD_API_KEY` / `CONFLUENT_CLOUD_API_SECRET` env vars | Environments, clusters, API keys |
+| **Data plane** | Cluster-scoped API key/secret | Auto-resolved from `.confluent-context.json`, or passed as tool parameters | Topics (create, list, delete) |
+
+Generate Cloud API keys at https://confluent.cloud/settings/api-keys (use "Cloud resource management" type).
+
+## API Key Storage
+
+Cluster-scoped API keys are automatically saved to `.confluent-context.json` when created via `create_api_key`, and removed when deleted via `delete_api_key`. Data plane tools (`create_topic`, `list_topics`, `delete_topic`) auto-resolve credentials from this file when `cluster_api_key`/`cluster_api_secret` are not explicitly provided.
+
+Keys are stored by `resource_id` (one key per resource, newest overwrites):
+
+```json
+{
+  "environment_id": "env-abc123",
+  "environment_name": "production",
+  "api_keys": {
+    "lkc-abc123": {
+      "api_key": "ABCDEFGHIJKLMNOP",
+      "api_secret": "cflt...",
+      "resource_kind": "Cluster",
+      "display_name": "my-kafka-cluster-key",
+      "created_at": "2026-02-12T19:10:37Z"
+    }
+  }
+}
+```
+
+## Tools (15 total)
+
+### Management Plane (via Confluent Cloud REST API)
+
+| Tool | Description |
+|------|-------------|
+| `create_environment` | Create a new environment |
+| `list_environments` | List all environments |
+| `update_environment` | Update environment name or governance package |
+| `delete_environment` | Delete an environment (must be empty) |
+| `create_cluster` | Create a Kafka cluster (async — returns PROVISIONING) |
+| `get_cluster` | Get cluster details / poll provisioning status |
+| `list_clusters` | List clusters in an environment |
+| `delete_cluster` | Delete a cluster (irreversible) |
+| `create_api_key` | Create a cluster-scoped API key |
+| `list_api_keys` | List API keys (optional resource filter) |
+| `delete_api_key` | Delete an API key |
+
+### Data Plane (via Kafka REST API, cluster-scoped credentials)
+
+| Tool | Description |
+|------|-------------|
+| `create_topic` | Create a topic (default 6 partitions, 7d retention) |
+| `list_topics` | List all topics in a cluster |
+| `delete_topic` | Delete a topic (irreversible) |
+
+## Slash Commands
+
+| Command | Description |
+|---------|-------------|
+| `/project:environments-create` | Create environment with governance options |
+| `/project:environments-list` | List all environments |
+| `/project:environments-use` | Set active environment for subsequent commands |
+| `/project:environments-update` | Update environment name or governance package |
+| `/project:environments-delete` | Delete environment (checks for clusters first) |
+| `/project:clusters-create` | Create cluster + wait + API key |
+| `/project:clusters-list` | List clusters in an environment |
+| `/project:clusters-delete` | Delete a cluster |
+| `/project:topics-create` | Create topic (auto-resolves cluster API key) |
+| `/project:topics-list` | List topics in a cluster |
+| `/project:topics-delete` | Delete a topic |
+| `/project:api-keys-create` | Create cluster-scoped API key |
+| `/project:api-keys-list` | List API keys |
+| `/project:api-keys-delete` | Delete an API key |
+| `/project:setup-streaming-app` | End-to-end: env → cluster → key → topics → app scaffold |
+
+## Common Cloud Regions
+
+| AWS | GCP | Azure |
+|-----|-----|-------|
+| us-east-1 | us-east1 | eastus |
+| us-west-2 | us-west1 | westus2 |
+| eu-west-1 | europe-west1 | westeurope |
+| eu-central-1 | europe-west2 | southeastasia |
+| ap-southeast-1 | asia-southeast1 | |
+| ap-southeast-2 | | |
+
+## Error Recovery
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| "Missing required environment variables" | Cloud API key not set | `export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...` and restart Claude Code |
+| "Cluster does not have a REST endpoint yet" | Cluster still provisioning | Poll `get_cluster` until status is PROVISIONED |
+| HTTP 401 on topic operations | Wrong or expired cluster API key | Create a new cluster-scoped key with `create_api_key` |
+| "environment must be empty" on delete | Clusters still exist | Delete all clusters first with `delete_cluster` |
+| HTTP 409 on topic create | Topic already exists | Choose a different name or delete existing topic |
+| "No cluster API credentials provided and none found" | No stored key for this cluster | Create a cluster-scoped key with `create_api_key` (it will be saved automatically) |
+
+## Build
+
+```bash
+npm install && npm run build
+```
+
+The `prebuild` script cleans `dist/` automatically. Output goes to `dist/index.js`.
+
+## API Documentation
+
+- Confluent Cloud REST API: https://docs.confluent.io/cloud/current/api.html
+- Kafka REST API v3: https://docs.confluent.io/cloud/current/api.html#tag/Topic-(v3)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+SHELL := /bin/bash
+
+.PHONY: show-args init-ci build test release-ci epilogue-ci testbreak-after
+
+show-args:
+	@echo "[show-args] branch=$${SEMAPHORE_GIT_BRANCH:-local} commit=$${SEMAPHORE_GIT_SHA:-local}"
+
+init-ci:
+	npm ci
+
+build:
+	npm run build
+
+test:
+	@if npm run 2>/dev/null | grep -q " test"; then \
+		npm test; \
+	else \
+		echo "[test] no test script defined, skipping"; \
+	fi
+
+release-ci:
+	@echo "[release-ci] no-op"
+
+epilogue-ci:
+	@echo "[epilogue-ci] done"
+
+testbreak-after:
+	@echo "[testbreak-after] no-op"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Claude Code plugin that lets developers build Confluent Cloud infrastructure a
 
 ## Architecture
 
-This plugin provides a single MCP server (`confluent-infra`) with 14 tools covering full Confluent Cloud lifecycle management: infrastructure provisioning + data plane operations.
+This plugin provides a single MCP server (`confluent-infra`) with 15 tools covering full Confluent Cloud lifecycle management: infrastructure provisioning + data plane operations.
 
 ## Quick Start
 
@@ -43,27 +43,29 @@ Claude Code will automatically detect the `.mcp.json` configuration and start th
 ### 4. Use the slash commands
 
 **Environments:**
-- `/environments:create` — Create a new Confluent Cloud environment
-- `/environments:list` — List all environments
-- `/environments:delete` — Delete an environment
+- `/environments-create` — Create a new Confluent Cloud environment
+- `/environments-list` — List all environments
+- `/environments-update` — Update environment name or governance package
+- `/environments-use` — Set active environment for subsequent commands
+- `/environments-delete` — Delete an environment
 
 **Clusters:**
-- `/clusters:create` — Create a Kafka cluster (with provisioning wait + API key creation)
-- `/clusters:list` — List clusters in an environment
-- `/clusters:delete` — Delete a cluster
+- `/clusters-create` — Create a Kafka cluster (with provisioning wait + API key creation)
+- `/clusters-list` — List clusters in an environment
+- `/clusters-delete` — Delete a cluster
 
 **Topics:**
-- `/topics:create` — Create a Kafka topic
-- `/topics:list` — List topics in a cluster
-- `/topics:delete` — Delete a topic
+- `/topics-create` — Create a Kafka topic
+- `/topics-list` — List topics in a cluster
+- `/topics-delete` — Delete a topic
 
 **API Keys:**
-- `/api-keys:create` — Create a cluster-scoped API key
-- `/api-keys:list` — List API keys
-- `/api-keys:delete` — Delete an API key
+- `/api-keys-create` — Create a cluster-scoped API key
+- `/api-keys-list` — List API keys
+- `/api-keys-delete` — Delete an API key
 
 **Setup:**
-- `/setup:streaming-app` — Full end-to-end: environment → cluster → API key → topics → optional app scaffold
+- `/setup-streaming-app` — Full end-to-end: environment → cluster → API key → topics → optional app scaffold
 
 ## MCP Tools
 
@@ -73,6 +75,7 @@ Claude Code will automatically detect the `.mcp.json` configuration and start th
 |------|-------------|
 | `create_environment` | Create a Confluent Cloud environment |
 | `list_environments` | List all environments |
+| `update_environment` | Update environment name or governance package |
 | `delete_environment` | Delete an environment |
 | `create_cluster` | Create a Kafka cluster (returns immediately, async provisioning) |
 | `get_cluster` | Get cluster details and provisioning status |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,127 @@
-# claude-code-confluent-plugin
+# Confluent Cloud Claude Code Plugin
 
-This repository is part of the Confluent organization on GitHub.
-It is public and open to contributions from the community.
+A Claude Code plugin that lets developers build Confluent Cloud infrastructure and data streaming applications using natural language. Provides Claude Skills (slash commands) for managing environments, clusters, topics, and API keys — powered by MCP (Model Context Protocol).
 
-Please see the LICENSE file for contribution terms.
-Please see the CHANGELOG.md for details of recent updates.
+## Architecture
+
+This plugin provides a single MCP server (`confluent-infra`) with 14 tools covering full Confluent Cloud lifecycle management: infrastructure provisioning + data plane operations.
+
+## Quick Start
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) 22+
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)
+- A [Confluent Cloud](https://confluent.cloud/) account with an API key
+
+### 1. Clone and build
+
+```bash
+git clone https://github.com/confluentinc/claude-code-confluent-plugin.git
+cd claude-code-confluent-plugin
+npm install
+npm run build
+```
+
+### 2. Set environment variables
+
+```bash
+export CONFLUENT_CLOUD_API_KEY=your-api-key
+export CONFLUENT_CLOUD_API_SECRET=your-api-secret
+```
+
+Generate API keys at [Confluent Cloud Settings > API Keys](https://confluent.cloud/settings/api-keys). Use a Cloud resource management API key (not a cluster-scoped key).
+
+### 3. Open Claude Code
+
+```bash
+claude
+```
+
+Claude Code will automatically detect the `.mcp.json` configuration and start the MCP server.
+
+### 4. Use the slash commands
+
+**Environments:**
+- `/environments:create` — Create a new Confluent Cloud environment
+- `/environments:list` — List all environments
+- `/environments:delete` — Delete an environment
+
+**Clusters:**
+- `/clusters:create` — Create a Kafka cluster (with provisioning wait + API key creation)
+- `/clusters:list` — List clusters in an environment
+- `/clusters:delete` — Delete a cluster
+
+**Topics:**
+- `/topics:create` — Create a Kafka topic
+- `/topics:list` — List topics in a cluster
+- `/topics:delete` — Delete a topic
+
+**API Keys:**
+- `/api-keys:create` — Create a cluster-scoped API key
+- `/api-keys:list` — List API keys
+- `/api-keys:delete` — Delete an API key
+
+**Setup:**
+- `/setup:streaming-app` — Full end-to-end: environment → cluster → API key → topics → optional app scaffold
+
+## MCP Tools
+
+### Management Plane
+
+| Tool | Description |
+|------|-------------|
+| `create_environment` | Create a Confluent Cloud environment |
+| `list_environments` | List all environments |
+| `delete_environment` | Delete an environment |
+| `create_cluster` | Create a Kafka cluster (returns immediately, async provisioning) |
+| `get_cluster` | Get cluster details and provisioning status |
+| `list_clusters` | List clusters in an environment |
+| `delete_cluster` | Delete a cluster |
+| `create_api_key` | Create a cluster-scoped API key |
+| `list_api_keys` | List API keys (optional resource filter) |
+| `delete_api_key` | Delete an API key |
+
+### Data Plane (requires cluster-scoped API credentials)
+
+| Tool | Description |
+|------|-------------|
+| `create_topic` | Create a Kafka topic |
+| `list_topics` | List all topics in a cluster |
+| `delete_topic` | Delete a topic |
+
+## Configuration
+
+The `.mcp.json` file configures the MCP server:
+
+```json
+{
+  "mcpServers": {
+    "confluent-infra": {
+      "command": "node",
+      "args": ["dist/index.js"],
+      "env": {
+        "CONFLUENT_CLOUD_API_KEY": "${CONFLUENT_CLOUD_API_KEY}",
+        "CONFLUENT_CLOUD_API_SECRET": "${CONFLUENT_CLOUD_API_SECRET}"
+      }
+    }
+  }
+}
+```
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Build (cleans dist/ first)
+npm run build
+
+# Watch mode
+npm run dev
+```
+
+## License
+
+Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1180 @@
+{
+  "name": "@confluentinc/claude-code-confluent-plugin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@confluentinc/claude-code-confluent-plugin",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.23.0"
+      },
+      "bin": {
+        "claude-code-confluent-plugin": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
+      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@confluentinc/claude-code-confluent-plugin",
+  "version": "0.1.0",
+  "description": "Claude Code plugin for Confluent Cloud infrastructure provisioning",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "claude-code-confluent-plugin": "dist/index.js"
+  },
+  "scripts": {
+    "prebuild": "rm -rf dist",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "license": "Apache-2.0"
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,142 @@
+const DEFAULT_BASE_URL = "https://api.confluent.cloud";
+
+interface ConfluentClientConfig {
+  apiKey: string;
+  apiSecret: string;
+  baseUrl?: string;
+}
+
+interface PaginatedResponse<T> {
+  api_version: string;
+  kind: string;
+  metadata: {
+    first?: string;
+    last?: string;
+    prev?: string;
+    next?: string;
+    total_size?: number;
+  };
+  data: T[];
+}
+
+interface ApiError {
+  error: {
+    code: number;
+    message: string;
+    details?: unknown[];
+  };
+}
+
+export class ConfluentClient {
+  private authHeader: string;
+  private baseUrl: string;
+
+  constructor(config: ConfluentClientConfig) {
+    const credentials = Buffer.from(
+      `${config.apiKey}:${config.apiSecret}`
+    ).toString("base64");
+    this.authHeader = `Basic ${credentials}`;
+    this.baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+  }
+
+  static fromEnv(): ConfluentClient {
+    const apiKey = process.env.CONFLUENT_CLOUD_API_KEY;
+    const apiSecret = process.env.CONFLUENT_CLOUD_API_SECRET;
+    const baseUrl = process.env.CONFLUENT_CLOUD_ENDPOINT;
+
+    if (!apiKey || !apiSecret) {
+      throw new Error(
+        "Missing required environment variables: CONFLUENT_CLOUD_API_KEY and CONFLUENT_CLOUD_API_SECRET"
+      );
+    }
+
+    return new ConfluentClient({ apiKey, apiSecret, baseUrl });
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    baseUrl?: string
+  ): Promise<T> {
+    const url = `${baseUrl ?? this.baseUrl}${path}`;
+
+    const headers: Record<string, string> = {
+      Authorization: this.authHeader,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    };
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    const responseBody = await response.text();
+
+    if (!response.ok) {
+      let errorMessage: string;
+      try {
+        const errorJson = JSON.parse(responseBody) as ApiError;
+        errorMessage =
+          errorJson.error?.message ?? `HTTP ${response.status}: ${responseBody}`;
+      } catch {
+        errorMessage = `HTTP ${response.status}: ${responseBody}`;
+      }
+      throw new Error(errorMessage);
+    }
+
+    if (!responseBody) {
+      return undefined as T;
+    }
+
+    return JSON.parse(responseBody) as T;
+  }
+
+  async get<T>(path: string, baseUrl?: string): Promise<T> {
+    return this.request<T>("GET", path, undefined, baseUrl);
+  }
+
+  async post<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>("POST", path, body);
+  }
+
+  async patch<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>("PATCH", path, body);
+  }
+
+  async delete<T>(path: string): Promise<T> {
+    return this.request<T>("DELETE", path);
+  }
+
+  async listAll<T>(path: string): Promise<T[]> {
+    const results: T[] = [];
+    let nextUrl: string | undefined = `${this.baseUrl}${path}`;
+
+    while (nextUrl) {
+      const separator = nextUrl.includes("?") ? "&" : "?";
+      const urlWithPageSize = nextUrl.includes("page_size")
+        ? nextUrl
+        : `${nextUrl}${separator}page_size=100`;
+
+      const response = await fetch(urlWithPageSize, {
+        headers: {
+          Authorization: this.authHeader,
+          Accept: "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`HTTP ${response.status}: ${text}`);
+      }
+
+      const body = (await response.json()) as PaginatedResponse<T>;
+      results.push(...body.data);
+      nextUrl = body.metadata.next ?? undefined;
+    }
+
+    return results;
+  }
+}

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,79 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Derive project root from script location (dist/context.js → one level up)
+// This is reliable regardless of the MCP server process's cwd.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = join(__dirname, "..");
+const CONTEXT_PATH = join(PROJECT_ROOT, ".confluent-context.json");
+
+export interface ApiKeyEntry {
+  api_key: string;
+  api_secret: string;
+  resource_kind: string;
+  display_name: string;
+  created_at: string;
+}
+
+export interface ContextFile {
+  environment_id?: string;
+  environment_name?: string;
+  api_keys?: Record<string, ApiKeyEntry>;
+}
+
+export async function readContext(): Promise<ContextFile> {
+  try {
+    const raw = await readFile(CONTEXT_PATH, "utf-8");
+    return JSON.parse(raw) as ContextFile;
+  } catch {
+    return {};
+  }
+}
+
+export async function writeContext(ctx: ContextFile): Promise<void> {
+  await writeFile(CONTEXT_PATH, JSON.stringify(ctx, null, 2) + "\n", "utf-8");
+}
+
+export async function saveApiKey(
+  resourceId: string,
+  apiKey: string,
+  apiSecret: string,
+  resourceKind: string,
+  displayName: string
+): Promise<void> {
+  const ctx = await readContext();
+  if (!ctx.api_keys) {
+    ctx.api_keys = {};
+  }
+  ctx.api_keys[resourceId] = {
+    api_key: apiKey,
+    api_secret: apiSecret,
+    resource_kind: resourceKind,
+    display_name: displayName,
+    created_at: new Date().toISOString(),
+  };
+  await writeContext(ctx);
+}
+
+export async function removeApiKey(apiKeyId: string): Promise<void> {
+  const ctx = await readContext();
+  if (!ctx.api_keys) return;
+  for (const [resourceId, entry] of Object.entries(ctx.api_keys)) {
+    if (entry.api_key === apiKeyId) {
+      delete ctx.api_keys[resourceId];
+      await writeContext(ctx);
+      return;
+    }
+  }
+}
+
+export async function getApiKeyForResource(
+  resourceId: string
+): Promise<{ api_key: string; api_secret: string } | null> {
+  const ctx = await readContext();
+  const entry = ctx.api_keys?.[resourceId];
+  if (!entry) return null;
+  return { api_key: entry.api_key, api_secret: entry.api_secret };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,607 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { ConfluentClient } from "./api/client.js";
+import { saveApiKey, removeApiKey, getApiKeyForResource } from "./context.js";
+
+const server = new McpServer({
+  name: "confluent-infra",
+  version: "0.1.0",
+});
+
+let client: ConfluentClient;
+
+function getClient(): ConfluentClient {
+  if (!client) {
+    client = ConfluentClient.fromEnv();
+  }
+  return client;
+}
+
+function ok(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+function fail(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: "text" as const, text: `Error: ${message}` }],
+    isError: true as const,
+  };
+}
+
+async function withClusterRestApi(
+  cluster_id: string,
+  environment_id: string,
+  cluster_api_key: string,
+  cluster_api_secret: string,
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<unknown> {
+  const cluster = await getClient().get<{ spec: { http_endpoint: string } }>(
+    `/cmk/v2/clusters/${cluster_id}?environment=${environment_id}`
+  );
+  const restEndpoint = cluster.spec.http_endpoint;
+  if (!restEndpoint) {
+    throw new Error(
+      "Cluster does not have a REST endpoint yet. Is it still provisioning?"
+    );
+  }
+  const credentials = Buffer.from(
+    `${cluster_api_key}:${cluster_api_secret}`
+  ).toString("base64");
+  const response = await fetch(`${restEndpoint}${path}`, {
+    method,
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const responseBody = await response.text();
+  if (!response.ok) throw new Error(`HTTP ${response.status}: ${responseBody}`);
+  return responseBody ? JSON.parse(responseBody) : undefined;
+}
+
+async function resolveClusterCredentials(
+  cluster_id: string,
+  cluster_api_key?: string,
+  cluster_api_secret?: string
+): Promise<{ api_key: string; api_secret: string }> {
+  if (cluster_api_key && cluster_api_secret) {
+    return { api_key: cluster_api_key, api_secret: cluster_api_secret };
+  }
+  const stored = await getApiKeyForResource(cluster_id);
+  if (stored) return stored;
+  throw new Error(
+    `No cluster API credentials provided and none found in .confluent-context.json for ${cluster_id}. ` +
+      `Create one with create_api_key first.`
+  );
+}
+
+// ============================================================
+// Environments
+// ============================================================
+
+// --- create_environment ---
+
+server.tool(
+  "create_environment",
+  "Create a new Confluent Cloud environment. Environments are containers for Kafka clusters and other resources.",
+  {
+    display_name: z.string().describe("A human-readable name for the environment"),
+    stream_governance_package: z
+      .enum(["ESSENTIALS", "ADVANCED"])
+      .optional()
+      .describe("Stream governance package level. ESSENTIALS enables Schema Registry."),
+  },
+  async ({ display_name, stream_governance_package }) => {
+    try {
+      const body: Record<string, unknown> = { display_name };
+      if (stream_governance_package) {
+        body.stream_governance = { package: stream_governance_package };
+      }
+      const result = await getClient().post("/org/v2/environments", body);
+      return ok(result);
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// --- list_environments ---
+
+server.tool(
+  "list_environments",
+  "List all Confluent Cloud environments in the organization. Returns environment IDs, names, and stream governance settings.",
+  {},
+  async () => {
+    try {
+      const result = await getClient().listAll("/org/v2/environments");
+      return ok(result);
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// --- update_environment ---
+
+server.tool(
+  "update_environment",
+  "Update an existing Confluent Cloud environment. Can rename or change the stream governance package. Note: downgrading from ADVANCED to ESSENTIALS is not allowed once Schema Registry is provisioned.",
+  {
+    environment_id: z
+      .string()
+      .describe("The environment ID to update (e.g., env-abc123)"),
+    display_name: z
+      .string()
+      .optional()
+      .describe("New name for the environment"),
+    stream_governance_package: z
+      .enum(["ESSENTIALS", "ADVANCED"])
+      .optional()
+      .describe(
+        'Stream governance package: "ESSENTIALS" or "ADVANCED". Downgrading from ADVANCED to ESSENTIALS is not allowed once Schema Registry is provisioned.'
+      ),
+  },
+  async ({ environment_id, display_name, stream_governance_package }) => {
+    try {
+      const body: Record<string, unknown> = {};
+      if (display_name) {
+        body.display_name = display_name;
+      }
+      if (stream_governance_package) {
+        body.stream_governance = { package: stream_governance_package };
+      }
+      const result = await getClient().patch(
+        `/org/v2/environments/${environment_id}`,
+        body
+      );
+      return ok(result);
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// --- delete_environment ---
+
+server.tool(
+  "delete_environment",
+  "Delete a Confluent Cloud environment. WARNING: All clusters and resources in the environment must be deleted first.",
+  {
+    environment_id: z
+      .string()
+      .describe("The environment ID to delete (e.g., env-abc123)"),
+  },
+  async ({ environment_id }) => {
+    try {
+      await getClient().delete(`/org/v2/environments/${environment_id}`);
+      return ok({ deleted: true, environment_id });
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// ============================================================
+// Clusters
+// ============================================================
+
+// --- create_cluster ---
+
+server.tool(
+  "create_cluster",
+  "Create a new Kafka cluster in a Confluent Cloud environment. Returns immediately with a cluster ID — the cluster will be in PROVISIONING status. Use get_cluster to poll until status is PROVISIONED.",
+  {
+    display_name: z.string().describe("A human-readable name for the cluster"),
+    environment_id: z
+      .string()
+      .describe("The environment ID (e.g., env-abc123) to create the cluster in"),
+    cloud: z.enum(["AWS", "GCP", "AZURE"]).describe("Cloud provider for the cluster"),
+    region: z
+      .string()
+      .describe(
+        "Cloud region for the cluster. Common regions — AWS: us-east-1, us-west-2, eu-west-1, eu-central-1, ap-southeast-1; GCP: us-east1, us-west1, europe-west1; Azure: eastus, westus2, westeurope."
+      ),
+    availability: z
+      .enum(["SINGLE_ZONE", "MULTI_ZONE"])
+      .optional()
+      .describe("Availability type. Defaults to SINGLE_ZONE."),
+    cluster_type: z
+      .enum(["BASIC", "STANDARD", "DEDICATED", "ENTERPRISE", "FREIGHT"])
+      .optional()
+      .describe("Cluster type. BASIC is cheapest and good for dev/test. Defaults to BASIC."),
+  },
+  async ({ display_name, environment_id, cloud, region, availability, cluster_type }) => {
+    try {
+      const type = cluster_type ?? "BASIC";
+      const kindMap: Record<string, string> = {
+        BASIC: "Basic",
+        STANDARD: "Standard",
+        DEDICATED: "Dedicated",
+        ENTERPRISE: "Enterprise",
+        FREIGHT: "Freight",
+      };
+      const specConfig: Record<string, unknown> = { kind: kindMap[type] ?? "Basic" };
+      if (type === "DEDICATED") {
+        specConfig.cku = 1;
+      }
+      const body = {
+        spec: {
+          display_name,
+          availability: availability ?? "SINGLE_ZONE",
+          cloud,
+          region,
+          config: specConfig,
+          environment: { id: environment_id, environment: environment_id },
+        },
+      };
+      const result = await getClient().post("/cmk/v2/clusters", body);
+      return ok(result);
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// --- get_cluster ---
+
+server.tool(
+  "get_cluster",
+  "Get details of a Kafka cluster including its provisioning status. Use this to poll until a newly created cluster reaches PROVISIONED status. The status is in the response at status.phase.",
+  {
+    cluster_id: z.string().describe("The cluster ID (e.g., lkc-abc123)"),
+    environment_id: z
+      .string()
+      .describe("The environment ID (e.g., env-abc123) the cluster belongs to"),
+  },
+  async ({ cluster_id, environment_id }) => {
+    try {
+      const result = await getClient().get(
+        `/cmk/v2/clusters/${cluster_id}?environment=${environment_id}`
+      );
+      return ok(result);
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// --- list_clusters ---
+
+server.tool(
+  "list_clusters",
+  "List all Kafka clusters in a Confluent Cloud environment. Returns cluster IDs, names, cloud/region, type, and status.",
+  {
+    environment_id: z
+      .string()
+      .describe("The environment ID (e.g., env-abc123) to list clusters for"),
+  },
+  async ({ environment_id }) => {
+    try {
+      const result = await getClient().listAll(
+        `/cmk/v2/clusters?environment=${environment_id}`
+      );
+      return ok(result);
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// --- delete_cluster ---
+
+server.tool(
+  "delete_cluster",
+  "Delete a Kafka cluster from a Confluent Cloud environment. This is irreversible — all topics and data in the cluster will be lost.",
+  {
+    cluster_id: z.string().describe("The cluster ID to delete (e.g., lkc-abc123)"),
+    environment_id: z
+      .string()
+      .describe("The environment ID (e.g., env-abc123) the cluster belongs to"),
+  },
+  async ({ cluster_id, environment_id }) => {
+    try {
+      await getClient().delete(
+        `/cmk/v2/clusters/${cluster_id}?environment=${environment_id}`
+      );
+      return ok({ deleted: true, cluster_id });
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// ============================================================
+// API Keys
+// ============================================================
+
+// --- create_api_key ---
+
+server.tool(
+  "create_api_key",
+  "Create a cluster-scoped API key for a Kafka cluster. Required for data plane operations (creating topics, producing, consuming). IMPORTANT: The API secret is only shown once — save it immediately.",
+  {
+    display_name: z.string().describe("A human-readable name for the API key"),
+    description: z.string().optional().describe("Description of the API key's purpose"),
+    environment_id: z.string().describe("The environment ID (e.g., env-abc123)"),
+    cluster_id: z
+      .string()
+      .describe("The cluster ID (e.g., lkc-abc123) to scope the key to"),
+  },
+  async ({ display_name, description, environment_id, cluster_id }) => {
+    try {
+      const apiKey = process.env.CONFLUENT_CLOUD_API_KEY;
+      if (!apiKey) {
+        throw new Error("Missing CONFLUENT_CLOUD_API_KEY environment variable");
+      }
+      const keyMeta = await getClient().get<{
+        spec: { owner: { id: string; api_version: string; kind: string } };
+      }>(`/iam/v2/api-keys/${apiKey}`);
+      const owner = keyMeta.spec.owner;
+
+      const body = {
+        spec: {
+          display_name,
+          description: description ?? "",
+          owner: {
+            id: owner.id,
+            api_version: owner.api_version,
+            kind: owner.kind,
+          },
+          resource: {
+            id: cluster_id,
+            environment: environment_id,
+          },
+        },
+      };
+      const result = await getClient().post<{
+        id: string;
+        spec: {
+          secret: string;
+          display_name: string;
+          resource: { id: string; kind: string };
+        };
+      }>("/iam/v2/api-keys", body);
+      try {
+        await saveApiKey(
+          cluster_id,
+          result.id,
+          result.spec.secret,
+          result.spec.resource?.kind ?? "Cluster",
+          result.spec.display_name
+        );
+      } catch {
+        // best-effort — don't fail the key creation if context save fails
+      }
+      return ok(result);
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// --- list_api_keys ---
+
+server.tool(
+  "list_api_keys",
+  "List API keys in the organization. Optionally filter by cluster resource ID to find keys scoped to a specific cluster.",
+  {
+    resource_id: z
+      .string()
+      .optional()
+      .describe(
+        "Optional cluster ID (e.g., lkc-abc123) to filter keys scoped to that resource"
+      ),
+  },
+  async ({ resource_id }) => {
+    try {
+      const path = resource_id
+        ? `/iam/v2/api-keys?spec.resource=${resource_id}`
+        : "/iam/v2/api-keys";
+      const result = await getClient().listAll(path);
+      return ok(result);
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// --- delete_api_key ---
+
+server.tool(
+  "delete_api_key",
+  "Delete an API key. This is irreversible — any applications using this key will lose access immediately.",
+  {
+    api_key_id: z
+      .string()
+      .describe("The API key ID to delete (e.g., the key string like ABCDEFGHIJKLMNOP)"),
+  },
+  async ({ api_key_id }) => {
+    try {
+      await getClient().delete(`/iam/v2/api-keys/${api_key_id}`);
+      try {
+        await removeApiKey(api_key_id);
+      } catch {
+        // best-effort — don't fail the deletion if context update fails
+      }
+      return ok({ deleted: true, api_key_id });
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// ============================================================
+// Topics (data plane — requires cluster-scoped API credentials)
+// ============================================================
+
+// --- create_topic ---
+
+server.tool(
+  "create_topic",
+  "Create a Kafka topic in a Confluent Cloud cluster. Cluster API credentials are auto-resolved from .confluent-context.json if not provided. Use create_api_key first to get cluster credentials.",
+  {
+    cluster_id: z.string().describe("The cluster ID (e.g., lkc-abc123)"),
+    environment_id: z
+      .string()
+      .describe("The environment ID (e.g., env-abc123) the cluster belongs to"),
+    cluster_api_key: z
+      .string()
+      .optional()
+      .describe("Cluster-scoped API key (from create_api_key). Auto-resolved from context if omitted."),
+    cluster_api_secret: z
+      .string()
+      .optional()
+      .describe("Cluster-scoped API secret (from create_api_key). Auto-resolved from context if omitted."),
+    topic_name: z.string().describe("Name of the topic to create"),
+    partitions_count: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Number of partitions. Defaults to 6."),
+    retention_ms: z
+      .number()
+      .int()
+      .optional()
+      .describe(
+        "Retention time in milliseconds. Defaults to 604800000 (7 days). Set to -1 for infinite."
+      ),
+  },
+  async ({
+    cluster_id,
+    environment_id,
+    cluster_api_key,
+    cluster_api_secret,
+    topic_name,
+    partitions_count,
+    retention_ms,
+  }) => {
+    try {
+      const creds = await resolveClusterCredentials(cluster_id, cluster_api_key, cluster_api_secret);
+      const topicBody: Record<string, unknown> = {
+        topic_name,
+        partitions_count: partitions_count ?? 6,
+      };
+      if (retention_ms !== undefined) {
+        topicBody.configs = [
+          { name: "retention.ms", value: String(retention_ms) },
+        ];
+      }
+      const result = await withClusterRestApi(
+        cluster_id,
+        environment_id,
+        creds.api_key,
+        creds.api_secret,
+        "POST",
+        `/kafka/v3/clusters/${cluster_id}/topics`,
+        topicBody
+      );
+      return ok(result ?? { topic_name });
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// --- list_topics ---
+
+server.tool(
+  "list_topics",
+  "List all topics in a Kafka cluster. Cluster API credentials are auto-resolved from .confluent-context.json if not provided.",
+  {
+    cluster_id: z.string().describe("The cluster ID (e.g., lkc-abc123)"),
+    environment_id: z
+      .string()
+      .describe("The environment ID (e.g., env-abc123) the cluster belongs to"),
+    cluster_api_key: z
+      .string()
+      .optional()
+      .describe("Cluster-scoped API key (from create_api_key). Auto-resolved from context if omitted."),
+    cluster_api_secret: z
+      .string()
+      .optional()
+      .describe("Cluster-scoped API secret (from create_api_key). Auto-resolved from context if omitted."),
+  },
+  async ({ cluster_id, environment_id, cluster_api_key, cluster_api_secret }) => {
+    try {
+      const creds = await resolveClusterCredentials(cluster_id, cluster_api_key, cluster_api_secret);
+      const result = await withClusterRestApi(
+        cluster_id,
+        environment_id,
+        creds.api_key,
+        creds.api_secret,
+        "GET",
+        `/kafka/v3/clusters/${cluster_id}/topics`
+      );
+      return ok(result);
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// --- delete_topic ---
+
+server.tool(
+  "delete_topic",
+  "Delete a Kafka topic from a cluster. This is irreversible — all messages in the topic will be lost. Cluster API credentials are auto-resolved from .confluent-context.json if not provided.",
+  {
+    cluster_id: z.string().describe("The cluster ID (e.g., lkc-abc123)"),
+    environment_id: z
+      .string()
+      .describe("The environment ID (e.g., env-abc123) the cluster belongs to"),
+    cluster_api_key: z
+      .string()
+      .optional()
+      .describe("Cluster-scoped API key (from create_api_key). Auto-resolved from context if omitted."),
+    cluster_api_secret: z
+      .string()
+      .optional()
+      .describe("Cluster-scoped API secret (from create_api_key). Auto-resolved from context if omitted."),
+    topic_name: z.string().describe("Name of the topic to delete"),
+  },
+  async ({
+    cluster_id,
+    environment_id,
+    cluster_api_key,
+    cluster_api_secret,
+    topic_name,
+  }) => {
+    try {
+      const creds = await resolveClusterCredentials(cluster_id, cluster_api_key, cluster_api_secret);
+      await withClusterRestApi(
+        cluster_id,
+        environment_id,
+        creds.api_key,
+        creds.api_secret,
+        "DELETE",
+        `/kafka/v3/clusters/${cluster_id}/topics/${topic_name}`
+      );
+      return ok({ deleted: true, topic_name });
+    } catch (error) {
+      return fail(error);
+    }
+  }
+);
+
+// --- Start server ---
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Adds MCP server (`confluent-infra`) with 15 tools for full Confluent Cloud lifecycle management
- Includes Claude Skills (slash commands) for environments, clusters, topics, API keys, and end-to-end streaming app setup
- Auto resolves cluster-scoped API credentials via `.confluent-context.json`

## Test plan
- [x] `npm install && npm run build` succeeds
- [x] MCP server starts when opening Claude Code in the project directory
- [x] Slash commands are available (e.g. `/environments-list`, `/clusters-create`)
- [x] Management plane operations work (create/list/delete environments, clusters, API keys)
- [x] Data plane operations work (create/list/delete topics with autoresolved credentials)