### PR TITLE
fix(manifest): make commands/mcpServers paths plugin-root-relative

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,6 +16,6 @@
     "confluent-cloud",
     "infrastructure"
   ],
-  "commands": "../.claude/commands",
-  "mcpServers": "../.mcp.json"
+  "commands": "./.claude/commands",
+  "mcpServers": "./.mcp.json"
 }


### PR DESCRIPTION
Hi — while preparing this plugin for Claude marketplace listing, we observed that `claude plugin validate` rejects the current manifest: `commands: "../.claude/commands"` and `mcpServers: "../.mcp.json"` are interpreted relative to the plugin root (the repository root), not the `.claude-plugin/` directory, and the leading `../` trips the CLI's path-traversal guard.

This PR makes both paths plugin-root-relative (`./.claude/commands`, `./.mcp.json`); `claude plugin validate` passes after the change.

One additional observation, not addressed in this PR: `.mcp.json` launches `node dist/index.js`, but `dist/` is gitignored, so a fresh plugin install has no built server to run. Committing the built output or pointing the server entry at a published package (e.g. via `npx`) would let the MCP server start on install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)